### PR TITLE
Make form fields more accessible

### DIFF
--- a/src/components/Forms/SubscribeForm.js
+++ b/src/components/Forms/SubscribeForm.js
@@ -137,8 +137,7 @@ class SubscribeForm extends React.Component {
                     />
                   </div>
                   <Field
-                    aria-label="your first name"
-                    aria-required="false"
+                    id="name"
                     name="name"
                     placeholder="Jane"
                     type="text"
@@ -155,7 +154,7 @@ class SubscribeForm extends React.Component {
                     />
                   </div>
                   <Field
-                    aria-label="your email address"
+                    id="email"
                     aria-required="true"
                     name="email"
                     placeholder="jane@acme.com"


### PR DESCRIPTION
I hope you don't mind me making this little change! 😊

Right now, when you click the label for each form field, the field is not focused because there was no `id` on the field to associate it with the label. Now that the label is properly associated with the field, there is no need for `aria-label` on the fields, since it will use the text within the label as the accessible name.

I also removed `aria-required="false"` from the name field, since we really only need to indicate whether or not a field *is* required. The default is false, so leaving it off is the same as providing false as a value. [(Source: MDN)](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-required_attribute)