### PR TITLE
Fix newsletter form submit button text is off center

### DIFF
--- a/src/components/Forms/SubscribeForm.js
+++ b/src/components/Forms/SubscribeForm.js
@@ -170,6 +170,7 @@ class SubscribeForm extends React.Component {
                     borderRadius: '3px',
                     fontSize: '16px',
                     padding: '10px 13px',
+                    alignItems: 'center',
                   })}
                 >
                   {!loading && 'Subscribe'}


### PR DESCRIPTION
Just a quick PR to center the newsletter submit button text.

## BEFORE

<img width="1317" alt="Screen Shot 2020-11-17 at 2 19 54 PM" src="https://user-images.githubusercontent.com/1474361/99458041-bf2b3f80-28e0-11eb-9c24-573a5f924646.png">

## AFTER

<img width="1316" alt="Screen Shot 2020-11-17 at 2 20 07 PM" src="https://user-images.githubusercontent.com/1474361/99458034-bb97b880-28e0-11eb-9712-dee69dab536c.png">
