### PR TITLE
fix twitter share card seo

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -35,7 +35,7 @@ export default function Index({ data: { site, allMdx } }) {
         <meta property="fb:app_id" content={fbAppID} />
 
         {/* Twitter Card tags */}
-        <meta name="twitter:card" />
+        <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:creator" content={twitter} />
         <meta name="twitter:title" content={title} />
         <meta name="twitter:description" content={description} />


### PR DESCRIPTION
I missed adding the `summary_large_image` for the twitter card.

![more glitter](https://media2.giphy.com/media/VBAp5ZoguHI5i/giphy.gif?cid=74e95743wyt8bsirxqq3pbv55mj94v7k6i3ci6i8ei0hakxq&rid=giphy.gif&ct=g)