### PR TITLE
Delete tilde ("~") suffix to fix package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "devDependencies": {
     "@babel/core": "^7.3.4",
     "babel-eslint": "^10.0.1",
-    "babel-preset-gatsby": "^0.1.8~",
+    "babel-preset-gatsby": "^0.1.8",
     "eslint": "^5.14.1",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-html": "^5.0.3",


### PR DESCRIPTION
`npm install` was failing.

It was a minor parsing issue in `package.json`.

`npm install` worked after removing the tilde suffix.